### PR TITLE
Optimize webRequest listeners usage

### DIFF
--- a/modules/core/sources/content.es
+++ b/modules/core/sources/content.es
@@ -130,15 +130,6 @@ registerContentScript({
       };
       window.addEventListener("mousedown", onMouseDown);
 
-      // Stop listening
-      window.addEventListener(
-        "unload",
-        () => {
-          window.removeEventListener("mousedown", onMouseDown);
-        },
-        { once: true }
-      );
-
       // Expose content actions
       return {
         getHTML,

--- a/modules/core/sources/content/run.es
+++ b/modules/core/sources/content/run.es
@@ -101,14 +101,5 @@ export default function () {
     contentScriptActions.setActionCallbacks(
       runContentScripts(window, chrome, WDP)
     );
-
-    // Stop listening for messages on window unload
-    window.addEventListener(
-      "unload",
-      () => {
-        contentScriptActions.unload();
-      },
-      { once: true }
-    );
   });
 }

--- a/modules/web-discovery-project/sources/background.es
+++ b/modules/web-discovery-project/sources/background.es
@@ -204,11 +204,11 @@ export default background({
 
     contentScriptTopAds() {},
 
-    jsRedirect(message) {
-      WebDiscoveryProject.httpCache[message.message.url] = {
+    jsRedirect({ url, location } = { url: undefined, location: undefined }) {
+      WebDiscoveryProject.httpCache[url] = {
         status: 301,
         time: WebDiscoveryProject.counter,
-        location: message.message.location,
+        location,
       };
     },
 

--- a/modules/web-discovery-project/sources/content.es
+++ b/modules/web-discovery-project/sources/content.es
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import runtime from "../platform/runtime";
-
 import { registerContentScript } from "../core/content/register";
 import { throttle } from "../core/decorators";
 
@@ -22,21 +20,9 @@ export function parseDom(url, window, wdp) {
     jsRef = document.querySelector("script");
     if (jsRef && jsRef.innerHTML.indexOf("location.replace") > -1) {
       const location = document.querySelector("title").textContent;
-      // NOTE: this should be migrated to use:
-      // WDP.modules['web-discovery-project'].action('jsRedirect', {
-      //   message: { ... }
-      // })
-      runtime.sendMessage({
-        module: "web-discovery-project",
-        action: "jsRedirect",
-        args: [
-          {
-            message: {
-              location,
-              url: document.location.href,
-            },
-          },
-        ],
+      wdp.modules['web-discovery-project'].action('jsRedirect', {
+        location,
+        url: document.location.href,
       });
     }
   } catch (ee) {
@@ -186,27 +172,6 @@ function contentScript(window, chrome, WDP) {
   window.addEventListener("mousemove", onMouseMove);
   window.addEventListener("scroll", onScroll);
   window.addEventListener("copy", onCopy);
-
-  function stop(ev) {
-    if (ev && ev.target !== window.document) {
-      return;
-    }
-
-    // detect dead windows
-    // https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Errors/Dead_object
-    try {
-      String(window);
-    } catch (e) {
-      return;
-    }
-
-    window.removeEventListener("keypress", onKeyPress);
-    window.removeEventListener("mousemove", onMouseMove);
-    window.removeEventListener("scroll", onScroll);
-    window.removeEventListener("copy", onCopy);
-  }
-
-  window.addEventListener("unload", stop);
 }
 
 registerContentScript({

--- a/modules/web-discovery-project/sources/content.es
+++ b/modules/web-discovery-project/sources/content.es
@@ -20,7 +20,7 @@ export function parseDom(url, window, wdp) {
     jsRef = document.querySelector("script");
     if (jsRef && jsRef.innerHTML.indexOf("location.replace") > -1) {
       const location = document.querySelector("title").textContent;
-      wdp.modules['web-discovery-project'].action('jsRedirect', {
+      wdp.action("jsRedirect", {
         location,
         url: document.location.href,
       });

--- a/modules/web-discovery-project/sources/doublefetch-handler.es
+++ b/modules/web-discovery-project/sources/doublefetch-handler.es
@@ -107,64 +107,68 @@ export default class DoublefetchHandler {
         "). Ignore and continue..."
       );
     };
-    return this._pendingInit.catch(logPreviousError).then(() => {
-      const requestStartedAt = new Date();
-      this._purgeObsoleteRequests(requestStartedAt);
 
-      if (this._state === State.DISABLED) {
-        this._stats.rejected.doubleFetchDisabled += 1;
-        return Promise.reject(
-          new Error(`doublefetch disabled: skipping request to fetch ${url}`)
-        );
-      }
+    try {
+      await this._pendingInit;
+    } catch (ex) {
+      logPreviousError(ex);
+    }
 
-      // bookkeeping: remember the request and clean it up in the end
-      const entry = { ts: requestStartedAt, url, originalUrl: url };
-      this._pendingRequests.push(entry);
-      logger.debug(
-        "doublefetch: pending requests",
-        this._pendingRequests.length
+    const requestStartedAt = Date.now();
+    this._purgeObsoleteRequests(requestStartedAt);
+
+    if (this._state === State.DISABLED) {
+      this._stats.rejected.doubleFetchDisabled += 1;
+      throw new Error(`doublefetch disabled: skipping request to fetch ${url}`);
+    }
+
+    // bookkeeping: remember the request and clean it up in the end
+    const entry = { ts: requestStartedAt, url, originalUrl: url };
+    this._pendingRequests.push(entry);
+    logger.debug(
+      "doublefetch: pending requests",
+      this._pendingRequests.length
+    );
+
+    // start the anonymous GET request (stripping cookies, etc)
+    this._stats.httpRequests.started += 1;
+    const requestPromise = this._makeRequestAndWaitForHandlers(
+      url,
+      entry,
+      3000,
+      overrideHeaders
+    );
+    entry.requestPromise = requestPromise;
+
+    try {
+      await requestPromise;
+    } catch (ex) {
+      logger.debug(ex);
+    }
+
+    const elapsedMs = Date.now() - requestStartedAt;
+    logger.debug(
+      `doublefetch for ${entry.url} completed after ${
+        elapsedMs / 1000
+      } seconds.`
+    );
+    this._stats.httpRequests.finished += 1;
+
+    const index = this._pendingRequests.indexOf(entry);
+    if (index !== -1) {
+      this._pendingRequests.splice(index, 1);
+    } else if (elapsedMs < this.zombieRequestTimelimitMs) {
+      logger.error(
+        `_pendingRequests is in an inconsistent state (url=${entry.url}).`
       );
+      this._stats.errors.inconsistentStateDetected += 1;
+    }
 
-      // start the anonymous GET request (stripping cookies, etc)
-      this._stats.httpRequests.started += 1;
-      const requestPromise = this._makeRequestAndWaitForHandlers(
-        url,
-        entry,
-        3000,
-        overrideHeaders
-      );
-      entry.requestPromise = requestPromise;
+    if (this._pendingRequests.length === 0) {
+      await this.unload();
+    }
 
-      requestPromise.catch(logger.debug).then(() => {
-        const elapsedMs = new Date() - requestStartedAt;
-        logger.debug(
-          `doublefetch for ${entry.url} completed after ${
-            elapsedMs / 1000
-          } seconds.`
-        );
-        this._stats.httpRequests.finished += 1;
-
-        const index = this._pendingRequests.indexOf(entry);
-        if (index !== -1) {
-          this._pendingRequests.splice(index, 1);
-        } else if (elapsedMs < this.zombieRequestTimelimitMs) {
-          logger.error(
-            `_pendingRequests is in an inconsistent state (url=${entry.url}).`
-          );
-          this._stats.errors.inconsistentStateDetected += 1;
-        }
-      });
-
-      return requestPromise;
-    }).catch((ex) => {
-      logger.error('Error while running double-fetch', ex);
-    }).then(async (response) => {
-      if (this._pendingRequests.length === 0) {
-        await this.unload();
-      }
-      return response; // forward response
-    });
+    return requestPromise;
   }
 
   _correlatePendingDoublefetchRequest(request) {

--- a/modules/web-discovery-project/sources/doublefetch-handler.es
+++ b/modules/web-discovery-project/sources/doublefetch-handler.es
@@ -125,10 +125,7 @@ export default class DoublefetchHandler {
     // bookkeeping: remember the request and clean it up in the end
     const entry = { ts: requestStartedAt, url, originalUrl: url };
     this._pendingRequests.push(entry);
-    logger.debug(
-      "doublefetch: pending requests",
-      this._pendingRequests.length
-    );
+    logger.debug("doublefetch: pending requests", this._pendingRequests.length);
 
     // start the anonymous GET request (stripping cookies, etc)
     this._stats.httpRequests.started += 1;
@@ -250,7 +247,13 @@ export default class DoublefetchHandler {
     // request. Note that the credentials=omit fetch init parameter
     // should already take care of cookies and HTTP basic auth, but
     // it's cheap to double-check.
-    const sensitiveHeaders = ["authorization", "cookie", "cookie2", "from", "origin"];
+    const sensitiveHeaders = [
+      "authorization",
+      "cookie",
+      "cookie2",
+      "from",
+      "origin",
+    ];
     function isSensitiveHeader(header) {
       const name = header.name.toLowerCase();
       if (sensitiveHeaders.includes(name.toLowerCase())) {

--- a/modules/web-discovery-project/sources/web-discovery-project.es
+++ b/modules/web-discovery-project/sources/web-discovery-project.es
@@ -3735,6 +3735,10 @@ const WebDiscoveryProject = {
     WebDiscoveryProject.safebrowsingEndpoint.unload();
 
     WebDiscoveryProject.patternsLoader.unload();
+
+    // NOTE - this should be called already after each double-fetch call, but
+    // we keep one last check here in case the extension is unloaded while
+    // double-fetch is happening.
     WebDiscoveryProject.doublefetchHandler.unload();
   },
   currentURL: function () {
@@ -4019,7 +4023,6 @@ const WebDiscoveryProject = {
           const promises = [];
 
           promises.push(WebDiscoveryProject.patternsLoader.init());
-          promises.push(WebDiscoveryProject.doublefetchHandler.init());
 
           // Load config from the backend
           promises.push(WebDiscoveryProject.fetchSafeQuorumConfig());

--- a/modules/web-discovery-project/tests/unit/doublefetch-handler-test.es
+++ b/modules/web-discovery-project/tests/unit/doublefetch-handler-test.es
@@ -443,7 +443,8 @@ export default describeModule(
       });
 
       it("should reject requests when state is DISABLED", function () {
-        expect(uut._state).to.equal(State.DISABLED);
+        expect(uut._state, "initial state should be DISABLED").to.equal(State.DISABLED);
+        uut.init = () => { }; // noop for the sake of this test
 
         let sent = false;
         scriptedRequests({

--- a/modules/webextension-specific/sources/app.bundle.es
+++ b/modules/webextension-specific/sources/app.bundle.es
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+import { newTab } from "../core/browser";
+import sleep from "../core/helpers/sleep";
 import App from "../core/app";
 
 const WDP = { app: undefined };
@@ -10,6 +12,88 @@ WDP.app = new App({
   version: chrome.runtime.getManifest().version,
 });
 window.WDP = WDP;
+
+function testStar() {
+  console.error("Fake message sending");
+  WDP.app.modules[
+    "web-discovery-project"
+  ].background.webDiscoveryProject.network.dns.cacheDnsResolution(
+    `remusao.github.io`,
+    "172.31.23.1"
+  );
+
+  let oc = 14;
+  const n = Date.now();
+  setTimeout(() => {
+    for (let i = 0; i < 5; i += 1) {
+      // Fake 'page message'
+      const page = {
+        type: "wdp",
+        action: "page",
+        oc: `${oc + i}`,
+        payload: {
+          url: `https://remusao.github.io/posts/packaging-nodejs-apps.html2`,
+          a: 2,
+          x: {
+            lh: 20729,
+            lt: 15503,
+            t: "Packaging Node.js apps the easy way",
+            nl: 12,
+            ni: 0,
+            ninh: 0,
+            nip: 0,
+            nf: 0,
+            pagel: "en",
+            ctry: "fr",
+            iall: true,
+            canonical_url: "https://remusao.github.io/ (PROTECTED)",
+            nfsh: 0,
+            nifsh: 0,
+            nifshmatch: true,
+            nfshmatch: true,
+            nifshbf: 0,
+            nfshbf: 0,
+          },
+          e: {
+            cp: 0,
+            mm: 0,
+            kp: 0,
+            sc: 0,
+            md: 0,
+          },
+          st: 200,
+          c: null,
+          ref: null,
+          red: null,
+          dur: 7841,
+        },
+        ver: "1.0",
+        channel: "brave",
+        ts: "20210912",
+        "anti-duplicates": n,
+      };
+
+      WDP.app.modules[
+        "web-discovery-project"
+      ].background.webDiscoveryProject.telemetry(page, false);
+    }
+  }, 5000);
+}
+
+function testDoubleFetch() {
+  setTimeout(async () => {
+    await Promise.all([
+      newTab('https://economist.com'),
+      newTab('https://www.economist.com/europe/2021/09/18/the-warring-parties-plans-for-germanys-economy-are-full-of-holes'),
+      newTab('https://remusao.github.io'),
+    ]);
+    await sleep(10000);
+    const results = await WDP.app.modules[
+      "web-discovery-project"
+    ].background.webDiscoveryProject._simulateDoublefetch();
+    console.error("??? results", results);
+  }, 2000);
+}
 
 WDP.app
   .start()
@@ -25,70 +109,8 @@ WDP.app
     ].background.webDiscoveryProject.patternsLoader.resourceWatcher.forceUpdate();
   })
   .then(() => {
-    console.error("Fake message sending");
-    WDP.app.modules[
-      "web-discovery-project"
-    ].background.webDiscoveryProject.network.dns.cacheDnsResolution(
-      `remusao.github.io`,
-      "172.31.23.1"
-    );
-
-    let oc = 14;
-    const n = Date.now();
-    setTimeout(() => {
-      for (let i = 0; i < 5; i += 1) {
-        // Fake 'page message'
-        const page = {
-          type: "wdp",
-          action: "page",
-          oc: `${oc + i}`,
-          payload: {
-            url: `https://remusao.github.io/posts/packaging-nodejs-apps.html2`,
-            a: 2,
-            x: {
-              lh: 20729,
-              lt: 15503,
-              t: "Packaging Node.js apps the easy way",
-              nl: 12,
-              ni: 0,
-              ninh: 0,
-              nip: 0,
-              nf: 0,
-              pagel: "en",
-              ctry: "fr",
-              iall: true,
-              canonical_url: "https://remusao.github.io/ (PROTECTED)",
-              nfsh: 0,
-              nifsh: 0,
-              nifshmatch: true,
-              nfshmatch: true,
-              nifshbf: 0,
-              nfshbf: 0,
-            },
-            e: {
-              cp: 0,
-              mm: 0,
-              kp: 0,
-              sc: 0,
-              md: 0,
-            },
-            st: 200,
-            c: null,
-            ref: null,
-            red: null,
-            dur: 7841,
-          },
-          ver: "1.0",
-          channel: "brave",
-          ts: "20210912",
-          "anti-duplicates": n,
-        };
-
-        WDP.app.modules[
-          "web-discovery-project"
-        ].background.webDiscoveryProject.telemetry(page, false);
-      }
-    }, 5000);
+    // testStar();
+    testDoubleFetch();
   })
   .catch((ex) => {
     console.error("????", ex);

--- a/modules/webextension-specific/sources/app.bundle.es
+++ b/modules/webextension-specific/sources/app.bundle.es
@@ -83,9 +83,11 @@ function testStar() {
 function testDoubleFetch() {
   setTimeout(async () => {
     await Promise.all([
-      newTab('https://economist.com'),
-      newTab('https://www.economist.com/europe/2021/09/18/the-warring-parties-plans-for-germanys-economy-are-full-of-holes'),
-      newTab('https://remusao.github.io'),
+      newTab("https://economist.com"),
+      newTab(
+        "https://www.economist.com/europe/2021/09/18/the-warring-parties-plans-for-germanys-economy-are-full-of-holes"
+      ),
+      newTab("https://remusao.github.io"),
     ]);
     await sleep(10000);
     const results = await WDP.app.modules[
@@ -109,7 +111,7 @@ WDP.app
     ].background.webDiscoveryProject.patternsLoader.resourceWatcher.forceUpdate();
   })
   .then(() => {
-    // testStar();
+    testStar();
     testDoubleFetch();
   })
   .catch((ex) => {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@babel/preset-env": "7.15.6",
     "@babel/preset-typescript": "7.15.0",
     "@types/chrome": "0.0.157",
+    "@types/mocha": "^9.0.0",
     "@types/node": "16.4.13",
     "@types/punycode": "2.1.0",
     "@typescript-eslint/eslint-plugin": "4.31.2",
@@ -113,10 +114,10 @@
     "ws": "8.2.2"
   },
   "dependencies": {
-    "dexie": "3.0.3",
     "@cliqz/url-parser": "1.1.4",
     "abortcontroller-polyfill": "1.7.3",
     "anonymous-credentials": "https://github.com/human-web/anonymous-credentials/releases/download/1.0.0/anonymous-credentials-1.0.0.tgz",
+    "dexie": "3.0.3",
     "pako": "2.0.4",
     "punycode": "2.1.1",
     "star-wasm": "https://github.com/brave/web-discovery-project/releases/download/star-wasm-0.1.3.tgz/star-wasm-0.1.3.tgz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,6 +1444,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
+"@types/mocha@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.0.0.tgz#3205bcd15ada9bc681ac20bef64e9e6df88fd297"
+  integrity sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA==
+
 "@types/node@*", "@types/node@>=10.0.0":
   version "16.9.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"


### PR DESCRIPTION
- [x] Only register webRequest listeners before a double-fetch and unload after last pending double-fetch is done.
- [x] Also remove the `unload` event listened to from content scripts.

Note for reviewers: you can ignore the content of `modules/webextension-specific/sources/app.bundle.es` as this is only needed for local debugging (this entry-point is not used when integrating WDP into Brave browser).