### PR TITLE
Replace window unload events by pagehide and add missing ones

### DIFF
--- a/modules/core/sources/content.es
+++ b/modules/core/sources/content.es
@@ -130,6 +130,9 @@ registerContentScript({
         recordMouseDown(ev, WDP);
       };
       window.addEventListener("mousedown", throttle(window, onMouseDown, 250));
+      window.addEventListener("pagehide", () => {
+        window.removeEventListener("mousedown", onMouseDown);
+      }, { once: true });
 
       // Expose content actions
       return {

--- a/modules/core/sources/content/run.es
+++ b/modules/core/sources/content/run.es
@@ -104,7 +104,7 @@ export default function () {
 
     // Stop listening for messages on window unload
     window.addEventListener(
-      "unload",
+      "pagehide",
       () => {
         contentScriptActions.unload();
       },

--- a/modules/web-discovery-project/sources/content.es
+++ b/modules/web-discovery-project/sources/content.es
@@ -173,6 +173,27 @@ function contentScript(window, chrome, WDP) {
   window.addEventListener("mousemove", onMouseMove);
   window.addEventListener("scroll", onScroll);
   window.addEventListener("copy", onCopy);
+
+  function stop(ev) {
+    if (ev && (ev.target !== window.document)) {
+      return;
+    }
+
+    // detect dead windows
+    // https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Errors/Dead_object
+    try {
+      String(window);
+    } catch (e) {
+      return;
+    }
+
+    window.removeEventListener("keypress", onKeyPress);
+    window.removeEventListener("mousemove", onMouseMove);
+    window.removeEventListener("scroll", onScroll);
+    window.removeEventListener("copy", onCopy);
+  }
+
+  window.addEventListener("pagehide", stop);
 }
 
 registerContentScript({

--- a/modules/webrequest-pipeline/tests/integration/webrequest-pipeline-test.es
+++ b/modules/webrequest-pipeline/tests/integration/webrequest-pipeline-test.es
@@ -266,7 +266,7 @@ export default () => {
           testServer.registerPathHandler(getSuffix(), {
             result: `<html><body><script>
               navigator.sendBeacon('${getSuffix("beacon")}', 'foo');
-              window.addEventListener('unload', () => {
+              window.addEventListener('pagehide', () => {
                 var client = new XMLHttpRequest();
                 client.open('GET', '${getSuffix("beacon")}', false);
                 client.send(null);
@@ -345,7 +345,7 @@ export default () => {
         testServer.registerPathHandler(getSuffix("frame"), {
           result: `<html><body><script>
             navigator.sendBeacon('${getSuffix("beacon")}', 'foo');
-            window.addEventListener('unload', () => {
+            window.addEventListener('pagehide', () => {
               navigator.sendBeacon('${getSuffix("beacon")}', 'bar');
               var client = new XMLHttpRequest();
               client.open('GET', '${getSuffix("beacon")}', ${


### PR DESCRIPTION
Context: https://web.dev/bfcache/#never-use-the-unload-event

TL;DR: registering `unload` event listeners disable back-forward caching in browsers, which makes back navigation much slower than it should be (i.e. it always reloads on back-navigation instead of being instantly loaded).