### PR TITLE
Add babel plugin to transpile optional chaining

### DIFF
--- a/broccoli/modules-tree.js
+++ b/broccoli/modules-tree.js
@@ -50,6 +50,7 @@ const babelOptions = {
   filterExtensions: ["es", "jsx", "ts", "tsx"],
   plugins: [
     "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-optional-chaining",
     ...(buildConfig.babelPlugins || []),
     ...(buildConfig.format === "common"
       ? ["@babel/plugin-transform-modules-commonjs"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/plugin-proposal-dynamic-import": "7.18.6",
         "@babel/plugin-transform-modules-commonjs": "7.23.0",
         "@babel/plugin-transform-modules-systemjs": "7.23.0",
+        "@babel/plugin-transform-optional-chaining": "^7.23.0",
         "@babel/plugin-transform-regenerator": "7.22.10",
         "@babel/plugin-transform-template-literals": "7.22.5",
         "@babel/preset-env": "7.23.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/plugin-proposal-dynamic-import": "7.18.6",
     "@babel/plugin-transform-modules-commonjs": "7.23.0",
     "@babel/plugin-transform-modules-systemjs": "7.23.0",
+    "@babel/plugin-transform-optional-chaining": "^7.23.0",
     "@babel/plugin-transform-regenerator": "7.22.10",
     "@babel/plugin-transform-template-literals": "7.22.5",
     "@babel/preset-env": "7.23.2",


### PR DESCRIPTION
This should fix the following error:
```
[2023-10-16T19:52:21.965Z] ERROR in ../out/Component/gen/brave/web-discovery-project/web-discovery-project/remote-resource-watcher.js 225:26
[2023-10-16T19:52:21.965Z] Module parse failed: Unexpected token (225:26)
[2023-10-16T19:52:21.965Z] You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
[2023-10-16T19:52:21.966Z] |       }
[2023-10-16T19:52:21.966Z] |       this.contentCache.loadLastUpdatedFromDisk();
[2023-10-16T19:52:21.966Z] >       this.signatureCache?.loadLastUpdatedFromDisk();
[2023-10-16T19:52:21.966Z] |       try {
[2023-10-16T19:52:21.966Z] |         this.verifiedContent = await this._loadFromDisk();
```