### PR TITLE
fix(socket-fix): set git identity via SOCKET_CLI_GIT_USER_* env vars

### DIFF
--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -39,7 +39,8 @@ jobs:
           GHSA_IDS: ${{ inputs.ghsa_ids }}
           SOCKET_SECURITY_API_KEY: ${{ secrets.SOCKET_SECURITY_API_KEY }}
           SOCKET_CLI_GITHUB_TOKEN: ${{ secrets.SOCKET_FIX_PAT }}
-          CI: 'true'
+          SOCKET_CLI_GIT_USER_NAME: brave-support-admin
+          SOCKET_CLI_GIT_USER_EMAIL: 138038132+brave-support-admin@users.noreply.github.com
         run: |
           if ! [[ "$GHSA_IDS" =~ ^GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}(,[[:space:]]?GHSA-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4})*$ ]]; then
             echo "::error::GHSA_IDS contains invalid entries. Expected format: GHSA-xxxx-xxxx-xxxx (comma or comma-space separated)"

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -50,23 +50,3 @@ jobs:
           for id in "${IDS[@]}"; do FLAGS+=(--id "${id// /}"); done
           socket config set defaultOrg "brave"
           socket fix . "${FLAGS[@]}"
-
-      - name: Compute branch name
-        id: branch
-        env:
-          GHSA_IDS: ${{ inputs.ghsa_ids }}
-        run: |
-          echo "name=socket-fix/$(echo "$GHSA_IDS" | tr ', ' '-' | tr -s '-' | cut -c1-60)" >> "$GITHUB_OUTPUT"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
-        with:
-          commit-message: 'fix: address security advisories'
-          author: brave-support-admin <138038132+brave-support-admin@users.noreply.github.com>
-          committer: brave-support-admin <138038132+brave-support-admin@users.noreply.github.com>
-          branch: ${{ steps.branch.outputs.name }}
-          delete-branch: true
-          base: main
-          title: 'fix: address security advisories'
-          body: 'Addresses: ${{ inputs.ghsa_ids }}'
-          token: ${{ secrets.SOCKET_FIX_PAT }}


### PR DESCRIPTION
## Problem

The socket-fix workflow produces commits that are GPG-signed but show as **unverified** on GitHub (reason: `unknown_key`).

## Root cause

GitHub Actions runners set `CI=true` automatically, so Socket CLI detects CI mode regardless of any `CI` env var we set in the workflow. In CI mode, Socket commits and opens the PR itself using `github-actions[bot]` as the commit author. The commit *is* GPG-signed with brave-support-admin's key (the Configure GPG step runs first), but GitHub looks up the signing key against the commit author's account (`github-actions[bot]`), which doesn't have that key registered — hence `unknown_key`.

## Fix

Socket CLI respects `SOCKET_CLI_GIT_USER_NAME` and `SOCKET_CLI_GIT_USER_EMAIL` for the commit author/committer identity. Setting these to `brave-support-admin` means Socket's commit will be authored by brave-support-admin, matching the GPG key's account, so GitHub will verify it.

## Verification

Next time the workflow is dispatched, the resulting PR's head commit should be authored by `brave-support-admin` and show as Verified.