### PR TITLE
fix(socket-fix): reference correct GPG secret name

### DIFF
--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Configure GPG
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
-          gpg_private_key: ${{ secrets.BRAVE_SUPPORT_ADMIN_GPG_KEY }}
+          gpg_private_key: ${{ secrets.BRAVE_SUPPORT_ADMIN_COMMIT_SIGNING_KEY }}
           passphrase: ${{ secrets.BRAVE_SUPPORT_ADMIN_COMMIT_SIGNING_KEY_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true


### PR DESCRIPTION
The Configure GPG step references `secrets.BRAVE_SUPPORT_ADMIN_GPG_KEY`, but that secret does not exist in this repo — the signing key is stored as `BRAVE_SUPPORT_ADMIN_COMMIT_SIGNING_KEY` (as in brave/leo). This made every socket-fix run fail at the GPG step, e.g. run 33577559557:

```
##[error]Input required and not supplied: gpg_private_key
```

Aligns the reference with the existing secret so socket-fix can produce signed PRs.