### PR TITLE
Fix high severity audit issues.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,13 @@ overrides:
   ansi-html: 0.0.9
   cookie: 0.7.0
   eslint: 9.39.2
+  fast-uri: 3.1.6
   serialize-javascript: 7.0.5
   tmp: 0.2.7
   micromatch: 4.0.8
   ws: 8.21.0
   uuid: 14.0.0
-  shell-quote: 1.8.4
+  shell-quote: 1.9.0
 
 patchedDependencies:
   broccoli@3.5.2: e38dca0d801776361ece690d750b7a05224c6e8de55964f0dbab5219291c60b1
@@ -2447,8 +2448,8 @@ packages:
     resolution: {integrity: sha512-7h9/x25c6AQwdU3mA8MZDUMR3UCy50f237egBrBkuwjnUZSmfu4ptCf91PZSKzON2Uh5VvIHozYKWcPPgcjxIw==}
     engines: {node: 10.* || >= 12.*}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3868,8 +3869,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
@@ -5808,7 +5809,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6420,7 +6421,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -6948,7 +6949,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastq@1.20.1:
     dependencies:
@@ -7132,7 +7133,7 @@ snapshots:
   fx-runner@1.6.0:
     dependencies:
       commander: 12.1.0
-      shell-quote: 1.8.4
+      shell-quote: 1.9.0
       which: 4.0.0
       winreg: 0.0.12
 
@@ -8422,7 +8423,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
   shellwords@0.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,12 +5,13 @@ overrides:
   ansi-html: 0.0.9
   cookie: 0.7.0
   eslint: 9.39.2
+  fast-uri: 3.1.6
   serialize-javascript: 7.0.5
   tmp: 0.2.7
   micromatch: 4.0.8
   ws: 8.21.0
   uuid: 14.0.0
-  shell-quote: 1.8.4
+  shell-quote: 1.9.0
 
 patchedDependencies:
   broccoli@3.5.2: patches/broccoli@3.5.2.patch


### PR DESCRIPTION
fast-uri:
https://github.com/advisories/GHSA-5jgf-p345-68v8
https://github.com/advisories/GHSA-f65p-4m7j-42xc
https://github.com/advisories/GHSA-fph4-wmhf-6fwf
https://github.com/advisories/GHSA-jqff-g426-hqxp

shell-quote:
https://github.com/advisories/GHSA-395f-4hp3-45gv

They currently prevent WDP bump here https://github.com/brave/brave-core/pull/39669